### PR TITLE
Changed test because of failure with proxy settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,11 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-/backend/target/
-/backend/src/target/
+
+# Ignore generated files in all subdirectories
+**/target/
+
+# Ignore eclipse specific files
+**/.settings
+**/.classpath
+**/.project

--- a/libraries/lib-datahandler/src/test/java/com/siemens/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
+++ b/libraries/lib-datahandler/src/test/java/com/siemens/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
@@ -95,7 +95,7 @@ public class AttachmentContentDownloaderTest {
                 } catch (ExecutionException e) {
                     Throwable futureException = e.getCause();
                     assertThat(futureException, is(notNullValue()));
-                    assertThat(futureException.getMessage(), containsString("timed out"));
+                    assertThat(futureException.getMessage(), either(containsString("timed out")).or(containsString("403")));
                 }
             } catch (TimeoutException e) {
                 fail("downloader got stuck on a black hole");


### PR DESCRIPTION
The testABlackHole test fails with „Server returned HTTP response code:
403 for URL: http://192.0.2.0/filename“ when there are proxy settings
(company network settings).