### PR TITLE
Mailing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ target/
 /libraries/importers/license-importer/target/
 /backend/src/src-projects/target/
 /backend/svc/svc-licenses/target/
+/backend/src-common/src/main/resources/sw360.properties

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -95,6 +95,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+            <version>1.4</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/backend/src-common/src/main/java/com/siemens/sw360/mail/MailConstants.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/mail/MailConstants.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License Version 2.0 as published by the
+ * Free Software Foundation with classpath exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License version 2.0 for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program (please see the COPYING file); if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+package com.siemens.sw360.mail;
+
+import com.siemens.sw360.datahandler.common.CommonUtils;
+
+import java.util.Properties;
+
+/**
+ * Constants for the MailUtil class.
+ *
+ * @author birgit.heydenreich@tngtech.com
+ */
+public class MailConstants {
+
+    public static final String MAIL_PROPERTIES_FILE_PATH = "/sw360.properties";
+
+    public static final String DEFAULT_BEGIN = "defaultBegin";
+    public static final String DEFAULT_END = "defaultEnd";
+    public static final String UNSUBSCRIBE_NOTICE_BEFORE = "unsubscribeNoticeBefore";
+    public static final String UNSUBSCRIBE_NOTICE_AFTER = "unsubscribeNoticeAfter";
+
+    public static final String SUBJECT_FOR_NEW_MODERATION_REQUEST = "subjectForNewModerationRequest";
+    public static final String SUBJECT_FOR_UPDATE_MODERATION_REQUEST = "subjectForUpdateModerationRequest";
+    public static final String SUBJECT_FOR_ACCEPTED_MODERATION_REQUEST = "subjectForAcceptedModerationRequest";
+    public static final String SUBJECT_FOR_DECLINED_MODERATION_REQUEST = "subjectForDeclinedModerationRequest";
+
+    public static final String TEXT_FOR_NEW_MODERATION_REQUEST = "textForNewModerationRequest";
+    public static final String TEXT_FOR_UPDATE_MODERATION_REQUEST = "textForUpdateModerationRequest";
+    public static final String TEXT_FOR_ACCEPTED_MODERATION_REQUEST = "textForAcceptedModerationRequest";
+    public static final String TEXT_FOR_DECLINED_MODERATION_REQUEST = "textForDeclinedModerationRequest";
+
+    private MailConstants() {
+        // Utility class with only static functions
+    }
+
+}

--- a/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
@@ -24,6 +24,7 @@ public class MailUtil {
     private String host;
     private String port;
     private String isAuthenticationNecessary;
+    private String enableStarttls;
     private String login;
     private String password;
 
@@ -43,6 +44,7 @@ public class MailUtil {
         isAuthenticationNecessary = loadedProperties.getProperty("MailUtil_isAuthenticationNecessary", "true");
         login = loadedProperties.getProperty("MailUtil_login", "");
         password = loadedProperties.getProperty("MailUtil_password", "");
+        enableStarttls=loadedProperties.getProperty("MaitUtil_enableStarttls","false");
     }
 
     private void setSession() {
@@ -53,7 +55,7 @@ public class MailUtil {
         properties.setProperty("mail.smtp.host", host);
         properties.setProperty("mail.smtp.port", port);
         properties.setProperty("mail.smtp.auth", isAuthenticationNecessary);
-        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.smtp.starttls.enable", enableStarttls);
 
         if (Boolean.parseBoolean(isAuthenticationNecessary)) {
             Authenticator auth = new SMTPAuthenticator(login, password);

--- a/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
@@ -7,6 +7,7 @@ import javax.mail.internet.*;
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.thrift.ThriftClients;
 import com.siemens.sw360.datahandler.thrift.users.User;
+import com.siemens.sw360.mail.MailConstants;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 
@@ -19,7 +20,6 @@ public class MailUtil {
 
     private static final Logger log = Logger.getLogger(MailUtil.class);
 
-    public static final String MAIL_PROPERTIES_FILE_PATH = "/sw360.properties";
     private Properties loadedProperties;
     private Session session;
 
@@ -36,7 +36,7 @@ public class MailUtil {
 
 
     public MailUtil() {
-        loadedProperties = CommonUtils.loadProperties(MailUtil.class, MAIL_PROPERTIES_FILE_PATH);
+        loadedProperties = CommonUtils.loadProperties(MailUtil.class, MailConstants.MAIL_PROPERTIES_FILE_PATH);
         setBasicProperties();
         setSession();
     }

--- a/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
@@ -27,6 +27,8 @@ public class MailUtil {
     private String enableStarttls;
     private String login;
     private String password;
+    private String enableSsl;
+    private String enableDebug;
 
     private String subject;
     private String text;
@@ -44,7 +46,9 @@ public class MailUtil {
         isAuthenticationNecessary = loadedProperties.getProperty("MailUtil_isAuthenticationNecessary", "true");
         login = loadedProperties.getProperty("MailUtil_login", "");
         password = loadedProperties.getProperty("MailUtil_password", "");
-        enableStarttls=loadedProperties.getProperty("MaitUtil_enableStarttls","false");
+        enableStarttls = loadedProperties.getProperty("MaitUtil_enableStarttls","false");
+        enableSsl = loadedProperties.getProperty("MaitUtil_enableSsl","false");
+        enableDebug = loadedProperties.getProperty("MaitUtil_enableDebug","false");
     }
 
     private void setSession() {
@@ -52,10 +56,14 @@ public class MailUtil {
         Properties properties = System.getProperties();
 
         // Setup mail server
+        properties.setProperty("mail.transport.protocol", "smtp");
         properties.setProperty("mail.smtp.host", host);
         properties.setProperty("mail.smtp.port", port);
         properties.setProperty("mail.smtp.auth", isAuthenticationNecessary);
         properties.setProperty("mail.smtp.starttls.enable", enableStarttls);
+        properties.setProperty("mail.smtp.ssl.enable", enableSsl);
+
+        properties.setProperty("mail.debug", enableDebug);
 
         if (Boolean.parseBoolean(isAuthenticationNecessary)) {
             Authenticator auth = new SMTPAuthenticator(login, password);

--- a/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/mail/MailUtil.java
@@ -1,0 +1,114 @@
+package com.siemens.sw360.mail;
+
+import java.util.*;
+import javax.mail.*;
+import javax.mail.internet.*;
+
+import com.siemens.sw360.datahandler.common.CommonUtils;
+import org.apache.log4j.Logger;
+
+/**
+ * Provides the possiblity to send mail from SW360
+ *
+ * @author birgit.heydenreich@tngtech.com
+ */
+public class MailUtil {
+
+    private static final Logger log = Logger.getLogger(MailUtil.class);
+
+    public static final String MAIL_PROPERTIES_FILE_PATH = "/sw360.properties";
+    private Properties loadedProperties;
+    private Session session;
+
+    private String from;
+    private String host;
+    private String port;
+    private String isAuthenticationNecessary;
+    private String login;
+    private String password;
+
+    private String subject;
+    private String text;
+
+    public MailUtil() {
+        loadedProperties = CommonUtils.loadProperties(MailUtil.class, MAIL_PROPERTIES_FILE_PATH);
+        setBasicProperties();
+        setSession();
+    }
+
+    private void setBasicProperties() {
+        from = loadedProperties.getProperty("MailUtil_from", "");
+        host = loadedProperties.getProperty("MailUtil_host", "localhost");
+        port = loadedProperties.getProperty("MailUtil_port", "25");
+        isAuthenticationNecessary = loadedProperties.getProperty("MailUtil_isAuthenticationNecessary", "true");
+        login = loadedProperties.getProperty("MailUtil_login", "");
+        password = loadedProperties.getProperty("MailUtil_password", "");
+    }
+
+    private void setSession() {
+        // Get system properties
+        Properties properties = System.getProperties();
+
+        // Setup mail server
+        properties.setProperty("mail.smtp.host", host);
+        properties.setProperty("mail.smtp.port", port);
+        properties.setProperty("mail.smtp.auth", isAuthenticationNecessary);
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+
+        if (Boolean.parseBoolean(isAuthenticationNecessary)) {
+            Authenticator auth = new SMTPAuthenticator(login, password);
+            session = Session.getInstance(properties, auth);
+        } else {
+            session = Session.getDefaultInstance(properties);
+        }
+    }
+
+    public void sendMail(String recipient, String subjectNameInPropertiesFile, String textNameInPropertiesFile) {
+        loadSubjectAndText(subjectNameInPropertiesFile,textNameInPropertiesFile);
+        sendMailWithSubjectAndText(recipient);
+    }
+
+    public void sendMail(Set<String> recipients, String subjectNameInPropertiesFile, String textNameInPropertiesFile) {
+        loadSubjectAndText(subjectNameInPropertiesFile,textNameInPropertiesFile);
+        for (String recipient : recipients) {
+            sendMailWithSubjectAndText(recipient);
+        }
+    }
+
+    private void loadSubjectAndText(String subjectKeyInPropertiesFile, String textKeyInPropertiesFile){
+        subject=loadedProperties.getProperty(subjectKeyInPropertiesFile,"");
+        text=loadedProperties.getProperty("defaultBegin","")
+            +loadedProperties.getProperty(textKeyInPropertiesFile,"")
+            +loadedProperties.getProperty("defaultEnd","");
+    }
+
+    private void sendMailWithSubjectAndText(String recipient) {
+        try {
+            MimeMessage message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(from));
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress(recipient));
+            message.setSubject(subject);
+            message.setText(text);
+
+            Transport.send(message);
+
+            log.info("Sent message successfully....");
+
+        } catch (MessagingException mex) {
+            log.error(mex.getMessage());
+        }
+    }
+
+    private class SMTPAuthenticator extends Authenticator {
+        private PasswordAuthentication authentication;
+
+        public SMTPAuthenticator(String login, String password) {
+            authentication = new PasswordAuthentication(login, password);
+        }
+
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            return authentication;
+        }
+    }
+}

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -18,6 +18,8 @@ MailUtil_password=
 MailUtil_port=
 MailUtil_isAuthenticationNecessary=
 MailUtil_enableStarttls=
+MailUtil_enableSsl=
+MailUtil_enableDebug=
 
 # text patterns for mail utility
 defaultBegin = \

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -1,5 +1,5 @@
 #
-# Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+# Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,3 +9,29 @@
 
 # common property file for the backend services
 backend.url= http://localhost:8080
+
+# settings for the mail utility:
+MailUtil_from=
+MailUtil_host=
+MailUtil_login=
+MailUtil_password=
+MailUtil_port=
+MailUtil_isAuthenticationNecessary= 
+
+# text patterns for mail utility
+defaultBegin = \
+  *** This is an automatically generated email, please do not reply ***\n\n\
+  Dear SW360-user,\n\n
+defaultEnd =
+
+subjectForNewModerationRequest= New moderation request
+subjectForUpdateModerationRequest= Update on moderation request
+subjectForAcceptedModerationRequest= Your moderation request has been accepted
+subjectForDeclinedModerationRequest= Your moderation request has been declined
+
+textForNewModerationRequest= a new moderation request has been added to your SW360-account.\n\n
+textForUpdateModerationRequest= \
+  one of the moderation requests previously added to your \
+  SW360-account has been updated.\n\n
+textForAcceptedModerationRequest= your moderation request has been accepted by one of the moderators.\n\n
+textForDeclinedModerationRequest= your moderation request has been declined by one of the moderators.\n\n

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -16,7 +16,8 @@ MailUtil_host=
 MailUtil_login=
 MailUtil_password=
 MailUtil_port=
-MailUtil_isAuthenticationNecessary= 
+MailUtil_isAuthenticationNecessary=
+MailUtil_enableStarttls=
 
 # text patterns for mail utility
 defaultBegin = \

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -11,15 +11,16 @@
 backend.url= http://localhost:8080
 
 # settings for the mail utility:
-MailUtil_from=
+# if host is not set, e-mailing is disabled
 MailUtil_host=
+MailUtil_from=
+MailUtil_port=25
+MailUtil_enableStarttls=false
+MailUtil_enableSsl=false
+MailUtil_isAuthenticationNecessary=false
 MailUtil_login=
 MailUtil_password=
-MailUtil_port=
-MailUtil_isAuthenticationNecessary=
-MailUtil_enableStarttls=
-MailUtil_enableSsl=
-MailUtil_enableDebug=
+MailUtil_enableDebug=false
 
 # text patterns for mail utility
 defaultBegin = \

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -1,5 +1,3 @@
-#in src-common/resources
-#
 # Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
 #
 # Copying and distribution of this file, with or without modification,
@@ -13,16 +11,16 @@ backend.url= http://localhost:8080
 
 # settings for the mail utility:
 # if host is not set, e-mailing is disabled
-MailUtil_host=w00cd5ef.kasserver.com
-MailUtil_from=test@maximilian-huber.de
+MailUtil_host=
+MailUtil_from=
 MailUtil_port=25
-MailUtil_enableStarttls=false
-MailUtil_enableSsl=true
-MailUtil_isAuthenticationNecessary=true
-MailUtil_login=m0379c39
-MailUtil_password=PTyfV5FQMFe87pvC
-MailUtil_enableDebug=false
-MailUtil_supportMailAddress=example@sw360.org
+MailUtil_enableStarttls=
+MailUtil_enableSsl=
+MailUtil_isAuthenticationNecessary=
+MailUtil_login=
+MailUtil_password=
+MailUtil_enableDebug=
+MailUtil_supportMailAddress=
 
 # text patterns for mail utility
 defaultBegin = \

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -1,3 +1,4 @@
+#in src-common/resources
 #
 # Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
 #
@@ -12,21 +13,26 @@ backend.url= http://localhost:8080
 
 # settings for the mail utility:
 # if host is not set, e-mailing is disabled
-MailUtil_host=
-MailUtil_from=
+MailUtil_host=w00cd5ef.kasserver.com
+MailUtil_from=test@maximilian-huber.de
 MailUtil_port=25
 MailUtil_enableStarttls=false
-MailUtil_enableSsl=false
-MailUtil_isAuthenticationNecessary=false
-MailUtil_login=
-MailUtil_password=
+MailUtil_enableSsl=true
+MailUtil_isAuthenticationNecessary=true
+MailUtil_login=m0379c39
+MailUtil_password=PTyfV5FQMFe87pvC
 MailUtil_enableDebug=false
+MailUtil_supportMailAddress=example@sw360.org
 
 # text patterns for mail utility
 defaultBegin = \
-  *** This is an automatically generated email, please do not reply ***\n\n\
+  *** This is an automatically generated email, please do not reply. ***\n\n\
   Dear SW360-user,\n\n
-defaultEnd =
+defaultEnd = \
+  With best regards,\n\
+  SW360-support
+unsubscribeNoticeBefore =\n\n*** If you do not wish to receive mails from SW360, please notify:
+unsubscribeNoticeAfter =. ***
 
 subjectForNewModerationRequest= New moderation request
 subjectForUpdateModerationRequest= Update on moderation request

--- a/backend/src/src-moderation/src/main/java/com/siemens/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/com/siemens/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -39,6 +39,7 @@ import com.siemens.sw360.datahandler.permissions.PermissionUtils;
 import com.siemens.sw360.datahandler.thrift.ThriftClients;
 import com.siemens.sw360.licenses.db.LicenseDatabaseHandler;
 import com.siemens.sw360.licenses.db.LicenseTypeRepository;
+import com.siemens.sw360.mail.MailConstants;
 import com.siemens.sw360.mail.MailUtil;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
@@ -278,17 +279,17 @@ public class ModerationDatabaseHandler {
 
     private void sendMailToModeratorsForNewRequest(Set<String> moderators){
         MailUtil mailUtil = new MailUtil();
-        mailUtil.sendMail(moderators,"subjectForNewModerationRequest","textForNewModerationRequest");
+        mailUtil.sendMail(moderators, MailConstants.SUBJECT_FOR_NEW_MODERATION_REQUEST,MailConstants.TEXT_FOR_NEW_MODERATION_REQUEST);
     }
 
     private void sendMailToModeratorsForUpdateRequest(Set<String> moderators){
         MailUtil mailUtil = new MailUtil();
-        mailUtil.sendMail(moderators,"subjectForUpdateModerationRequest","textForUpdateModerationRequest");
+        mailUtil.sendMail(moderators,MailConstants.SUBJECT_FOR_UPDATE_MODERATION_REQUEST,MailConstants.TEXT_FOR_UPDATE_MODERATION_REQUEST);
     }
 
     private void sendMailToUserForDeclinedRequest(String userEmail){
         MailUtil mailUtil = new MailUtil();
-        mailUtil.sendMail(userEmail,"subjectForDeclinedModerationRequest","textForDeclinedModerationRequest");
+        mailUtil.sendMail(userEmail,MailConstants.SUBJECT_FOR_DECLINED_MODERATION_REQUEST,MailConstants.TEXT_FOR_DECLINED_MODERATION_REQUEST);
     }
 
 

--- a/backend/src/src-moderation/src/main/java/com/siemens/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/com/siemens/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -18,7 +18,6 @@
 
 package com.siemens.sw360.moderation.db;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.SW360Utils;

--- a/backend/src/src-users/src/main/java/com/siemens/sw360/users/UserHandler.java
+++ b/backend/src/src-users/src/main/java/com/siemens/sw360/users/UserHandler.java
@@ -85,4 +85,10 @@ public class UserHandler implements UserService.Iface {
         return db.updateUser(user);
     }
 
+    public RequestStatus sendMailForAcceptedModerationRequest(String userEmail) throws TException {
+        assertNotNull(userEmail);
+        return db.sendMailForAcceptedModerationRequest(userEmail);
+
+    }
+
 }

--- a/backend/src/src-users/src/main/java/com/siemens/sw360/users/UserHandler.java
+++ b/backend/src/src-users/src/main/java/com/siemens/sw360/users/UserHandler.java
@@ -88,7 +88,6 @@ public class UserHandler implements UserService.Iface {
     public RequestStatus sendMailForAcceptedModerationRequest(String userEmail) throws TException {
         assertNotNull(userEmail);
         return db.sendMailForAcceptedModerationRequest(userEmail);
-
     }
 
 }

--- a/backend/src/src-users/src/main/java/com/siemens/sw360/users/UserHandler.java
+++ b/backend/src/src-users/src/main/java/com/siemens/sw360/users/UserHandler.java
@@ -56,7 +56,7 @@ public class UserHandler implements UserService.Iface {
         // Get user from database
         User user = db.getByEmail(email);
         if (user == null) {
-            log.error("Non existing user");
+            log.info("User does not exist in DB");
         }
         return user;
     }

--- a/backend/src/src-users/src/main/java/com/siemens/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/com/siemens/sw360/users/db/UserDatabaseHandler.java
@@ -20,6 +20,7 @@ package com.siemens.sw360.users.db;
 import com.siemens.sw360.datahandler.couchdb.DatabaseConnector;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
 import com.siemens.sw360.datahandler.thrift.users.User;
+import com.siemens.sw360.mail.MailConstants;
 import com.siemens.sw360.mail.MailUtil;
 
 import java.net.MalformedURLException;
@@ -69,7 +70,7 @@ public class UserDatabaseHandler {
     public RequestStatus sendMailForAcceptedModerationRequest(String userEmail) {
 
         MailUtil mailUtil = new MailUtil();
-        mailUtil.sendMail(userEmail,"subjectForAcceptedModerationRequest","textForAcceptedModerationRequest");
+        mailUtil.sendMail(userEmail, MailConstants.SUBJECT_FOR_ACCEPTED_MODERATION_REQUEST,MailConstants.TEXT_FOR_ACCEPTED_MODERATION_REQUEST);
 
         return RequestStatus.SUCCESS;
     }

--- a/backend/src/src-users/src/main/java/com/siemens/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/com/siemens/sw360/users/db/UserDatabaseHandler.java
@@ -70,8 +70,8 @@ public class UserDatabaseHandler {
 
         MailUtil mailUtil = new MailUtil();
         mailUtil.sendMail(userEmail,"subjectForAcceptedModerationRequest","textForAcceptedModerationRequest");
-        return RequestStatus.SUCCESS;
 
+        return RequestStatus.SUCCESS;
     }
 
     public List<User> getAll() {return repository.getAll();}

--- a/backend/src/src-users/src/main/java/com/siemens/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/com/siemens/sw360/users/db/UserDatabaseHandler.java
@@ -20,6 +20,7 @@ package com.siemens.sw360.users.db;
 import com.siemens.sw360.datahandler.couchdb.DatabaseConnector;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
 import com.siemens.sw360.datahandler.thrift.users.User;
+import com.siemens.sw360.mail.MailUtil;
 
 import java.net.MalformedURLException;
 import java.util.List;
@@ -63,6 +64,14 @@ public class UserDatabaseHandler {
         db.update(user);
 
         return RequestStatus.SUCCESS;
+    }
+
+    public RequestStatus sendMailForAcceptedModerationRequest(String userEmail) {
+
+        MailUtil mailUtil = new MailUtil();
+        mailUtil.sendMail(userEmail,"subjectForAcceptedModerationRequest","textForAcceptedModerationRequest");
+        return RequestStatus.SUCCESS;
+
     }
 
     public List<User> getAll() {return repository.getAll();}

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/admin/UserPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/admin/UserPortlet.java
@@ -213,23 +213,6 @@ public class UserPortlet extends Sw360Portlet {
                 department = organizations.get(0).getName();
             }
 
-            /*String userGroup = "";
-
-            List<Role> roles = liferayUser.getRoles();
-            List<String> roleNames = new ArrayList<>();
-
-            for (Role role : roles) {
-                roleNames.add(role.getName());
-            }
-
-            for (UserGroup group : UserGroup.values()) {
-                String roleConstantFromUserGroup = getRoleConstantFromUserGroup(group);
-                if (roleNames.contains(roleConstantFromUserGroup)) {
-                    userGroup = group.toString();
-                    break;
-                }
-            }*/
-
             String gid = liferayUser.getOpenId();
             boolean isMale = liferayUser.isMale();
             String passwordHash = liferayUser.getPassword();
@@ -238,7 +221,7 @@ public class UserPortlet extends Sw360Portlet {
             com.siemens.sw360.datahandler.thrift.users.User sw360user = UserCacheHolder.getUserFromEmail(emailAddress);
             boolean wantsMailNotification =
                     sw360user.isSetWantsMailNotification() ? sw360user.wantsMailNotification : true;
-
+String department = 
             String userGroup = sw360user.getUserGroup().toString();
 
             log.info("out:"+ csvPrinter.getOut().toString());

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/admin/UserPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/admin/UserPortlet.java
@@ -216,15 +216,14 @@ public class UserPortlet extends Sw360Portlet {
             String gid = liferayUser.getOpenId();
             boolean isMale = liferayUser.isMale();
             String passwordHash = liferayUser.getPassword();
-            if (isNullOrEmpty(emailAddress) || isNullOrEmpty(department))
+            if (isNullOrEmpty(emailAddress) || isNullOrEmpty(department)) {
                 continue;
+            }
             com.siemens.sw360.datahandler.thrift.users.User sw360user = UserCacheHolder.getUserFromEmail(emailAddress);
             boolean wantsMailNotification =
                     sw360user.isSetWantsMailNotification() ? sw360user.wantsMailNotification : true;
-String department = 
             String userGroup = sw360user.getUserGroup().toString();
 
-            log.info("out:"+ csvPrinter.getOut().toString());
             csvPrinter.printRecord(firstName, lastName, emailAddress, department, userGroup, gid, isMale, passwordHash, wantsMailNotification);
         }
 

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -38,6 +38,7 @@ import com.siemens.sw360.datahandler.thrift.projects.ProjectLink;
 import com.siemens.sw360.datahandler.thrift.projects.ProjectRelationship;
 import com.siemens.sw360.datahandler.thrift.projects.ProjectService;
 import com.siemens.sw360.datahandler.thrift.users.User;
+import com.siemens.sw360.datahandler.thrift.users.UserService;
 import com.siemens.sw360.portal.common.PortalConstants;
 import com.siemens.sw360.portal.portlets.FossologyAwarePortlet;
 import com.siemens.sw360.portal.users.UserCacheHolder;
@@ -161,6 +162,8 @@ public class ModerationPortlet extends FossologyAwarePortlet {
                     licenseClient.updateLicense(moderationRequest.getLicense(), user, requestingUser);
             }
         }
+        UserService.Iface userClient = thriftClients.makeUserClient();
+        userClient.sendMailForAcceptedModerationRequest(moderationRequest.getRequestingUser());
     }
 
     private void renderNextModeration(RenderRequest request, RenderResponse response, final User user, String sessionMessage, ModerationService.Iface client, ModerationRequest moderationRequest) throws IOException, PortletException, TException {

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -456,16 +456,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             projectList = Collections.emptyList();
         }
 
-        //Set<String> vendorNames;
-
-        //try {
-        //    vendorNames = thriftClients.makeVendorClient().getAllVendorNames();
-        //} catch (TException e) {
-        //    log.error("Problem retrieving all the Vendor names");
-        //    vendorNames = Collections.emptySet();
-
-
-        //request.setAttribute(VENDOR_LIST, new ThriftJsonSerializer().toJson(vendorNames));
         request.setAttribute(PROJECT_LIST, projectList);
         request.setAttribute(KEY_SEARCH_TEXT, searchtext);
         request.setAttribute(KEY_SEARCH_FILTER_TEXT, searchfilter);
@@ -495,9 +485,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 request.setAttribute(PortalConstants.RELEASES_AND_PROJECTS, releaseStringMap);
 
                 addProjectBreadcrumb(request, response, project);
-                log.info("in prepareDetailView:");
-                log.info(project.name);
-                log.info(project.description);
             } catch (TException e) {
                 log.error("Error fetching project from backend!", e);
             }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/users/UserCSV.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/users/UserCSV.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License Version 2.0 as published by the
+ * Free Software Foundation with classpath exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License version 2.0 for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program (please see the COPYING file); if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+package com.siemens.sw360.portal.users;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.model.User;
+import com.siemens.sw360.portal.portlets.admin.UserPortlet;
+import org.apache.commons.csv.CSVRecord;
+
+import javax.portlet.PortletRequest;
+
+import static com.siemens.sw360.portal.users.UserUtils.getRoleConstantFromUserGroup;
+import static com.siemens.sw360.portal.users.UserUtils.userGroupFromString;
+
+/**
+ * Created by heydenrb on 01.03.16.
+ *
+ * @author birgit.heydenreich@tngtech.com
+ */
+public class UserCSV {
+
+    private String givenname;
+    private String lastname;
+    private String email;
+    private String department;
+    private String group;
+    private String gid;
+    private boolean isMale;
+    private String hash;
+    private boolean wantsMailNotification = true;
+
+    public String getGivenname(){
+        return givenname;
+    }
+
+    public String getLastname() {
+        return lastname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getGid() {
+        return gid;
+    }
+
+    public boolean wantsMailNotification() {
+        return wantsMailNotification;
+    }
+
+    public UserCSV(CSVRecord record) {
+        givenname = record.get(0);
+        lastname = record.get(1);
+        email = record.get(2);
+        department = record.get(3);
+        group = record.get(4);
+        gid = record.get(5);
+        isMale = Boolean.parseBoolean(record.get(6));
+        hash = record.get(7);
+        if (record.size() > 8) {
+            wantsMailNotification = Boolean.parseBoolean((record.get(8)));
+        }
+    }
+
+    public User addLifeRayUser(PortletRequest request) throws PortalException, SystemException {
+        return UserPortlet.addLiferayUser(request, givenname, lastname, email,
+                department, getRoleConstantFromUserGroup(userGroupFromString(group)), isMale, gid, hash);
+
+    }
+
+}

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/users/UserUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/users/UserUtils.java
@@ -89,12 +89,12 @@ public class UserUtils {
             thriftUser = client.getByEmail(userCsv.getEmail());
         } catch (TException e) {
             //This occurs for every new user, so there is not necessarily something wrong
-            log.trace("Thrift exception when getting the user", e);
+            log.trace("User does not exist in DB yet.");
         }
 
         try {
             if (thriftUser == null) {
-                //we have a new user
+                log.info("Create new user.");
                 thriftUser = new com.siemens.sw360.datahandler.thrift.users.User();
                 fillThriftUserFromUserCSV(thriftUser, userCsv);
                 client.addUser(thriftUser);

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/couchdb/DatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/couchdb/DatabaseConnector.java
@@ -92,7 +92,7 @@ public class DatabaseConnector extends StdCouchDbConnector {
         try {
             return super.get(type, id);
         } catch (DocumentNotFoundException e) {
-            log.error("Document not found for ID: " + id, e);
+            log.info("Document not found for ID: " + id);
             return null;
         } catch (DbAccessException e) {
             log.error("Document ID " + id + " could not be successfully converted to " + type.getName(), e);

--- a/libraries/lib-datahandler/src/main/thrift/users.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/users.thrift
@@ -54,7 +54,8 @@ struct User {
     7: optional string fullname,
     8: optional string givenname, // firstname or given name of the person
     9: optional string lastname, // Lastname or Surname of the person
-    10: required string department, 
+    10: required string department,
+    11: optional bool wantsMailNotification,
 }
 
 service UserService {

--- a/libraries/lib-datahandler/src/main/thrift/users.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/users.thrift
@@ -66,4 +66,6 @@ service UserService {
 
     RequestStatus addUser(1: User user);
     RequestStatus updateUser(1: User user);
+
+    RequestStatus sendMailForAcceptedModerationRequest(1: string userEmail);
 }


### PR DESCRIPTION
closes #36

Features:
1. mail-notification can be sent to moderator about new and updated moderation requests
    and to the requesting user about acceptance/decline of his/her moderation request
2. added ```wantsMailNotification``` tag to user.thrift
    if field is not set in db, value is assumed to be ```true```
3. ```user.csv``` import and export with extra column ```wantsMailNotification```
    when importing old .csv-files without extra column, ```wantsMailNotification``` is set ```true``` in db
4. removed stacktrace from log about 'user not found in db', when importing new user - instead, shorter INFO is written to log

Configuration:
1. configuration of mail support necessary in ```sw360.properties``` on server in
   `` /webapps/classes/<name-of-portlet>/WEB-INF/classes/sw360.properties``
    for portlets ```moderation``` and ```users```
2. admin has to set ```wantsMailNotification``` for unsubscribing user in db